### PR TITLE
Fix syntax in default response to cases/ endpoint.

### DIFF
--- a/GQL_OSDF/app.py
+++ b/GQL_OSDF/app.py
@@ -60,7 +60,8 @@ def get_cases():
         return ('%s, "warnings": {}}' % r[:-1])
 
     else:
-        return jsonify({"filters": filters})
+        return jsonify({"data": {"hits": [], "pagination": {"count": 0, "sort": "case_id.raw:asc", "from": 1, "page": 1, "total": 166, "pages": 166, "size": 0}}, "warnings": {}, "filters": filters})
+
 
 # Route for specific cases endpoints that associates with various files
 @app.route('/cases/<case_id>', methods=['GET','OPTIONS'])


### PR DESCRIPTION
Changing the syntax of the default response to a cases/ request fixes some more JavaScript console errors (and also sets the default CASES count to 166 on the UI front page.)