### PR TITLE
Connect projects/endpoint to Neo4J. Test/hack - not using GraphQL 

### DIFF
--- a/GQL_OSDF/models.py
+++ b/GQL_OSDF/models.py
@@ -2,6 +2,7 @@ import re
 import graphene
 from py2neo import Graph # Using py2neo v3 not v2
 from query import match, build_cypher
+import sys
 
 ###################
 # DEFINING MODELS #
@@ -230,6 +231,16 @@ def get_proj_data(sample_id):
     cquery = "MATCH (p:Project)<-[:PART_OF]-(Study)<-[:PARTICIPATES_IN]-(SUBJECT)<-[:BY]-(VISIT)<-[:COLLECTED_DURING]-(Sample) WHERE Sample._id=\"%s\" RETURN p" % (sample_id)
     res = graph.data(cquery)
     return Project(name=res[0]['p']['name'],projectId=res[0]['p']['subtype'])
+
+def get_all_proj_data():
+    cquery = "MATCH (p:Project)<-[:PART_OF]-(Study)<-[:PARTICIPATES_IN]-(SUBJECT)<-[:BY]-(VISIT)<-[:COLLECTED_DURING]-(Sample) RETURN DISTINCT p"
+    res = graph.data(cquery)
+    return res
+
+def get_all_proj_counts():
+    cquery = "MATCH (p:Project)<-[:PART_OF]-(Study)<-[:PARTICIPATES_IN]-(SUBJECT)<-[:BY]-(VISIT)<-[:COLLECTED_DURING]-(Sample)<-[:PREPARED_FROM]-(pf)<-[:SEQUENCED_FROM]-(sf)<-[:COMPUTED_FROM]-(cf) RETURN DISTINCT p.id, p.name, Sample.body_site, (COUNT(sf)+COUNT(cf)) as file_count"
+    res = graph.data(cquery)
+    return res
 
 # Cypher query to count the amount of each distinct property
 def count_props(node, prop, cy):


### PR DESCRIPTION
Playing around with the projects/ endpoint. This commit should:
- Populate the "Cases by Primary Site" bar graph on the home page
- Make the "PROJECTS" box on the home page say "1" (with the corresponding portal-ui update to allow duplicate projects ids)

Not sure if this is the way to go, but the idea is to generalize the UI code to allow duplicate project ids, which is one way to have a many-to-1 mapping from projects to body sites. An alternative might be to have a special "multiple" body site for such cases. Note that the endpoint is currently hooked up directly in app.py and models.py without going through GraphQL correctly.
